### PR TITLE
fix: set_definition_string (closes #6)

### DIFF
--- a/src/ic_utils.cmake
+++ b/src/ic_utils.cmake
@@ -39,7 +39,7 @@ macro(set_definition_string name value)
         )
     endif()
 
-    if(DEFINED name)
+    if(DEFINED name AND NOT "${${name}}" STREQUAL "")
         message(FATAL_ERROR "${name} is already defined!")
     endif()
 


### PR DESCRIPTION
Still unsure what is causing this originally as it's quite rare to see! It seems like it happens when cmake "gets run twice", perhaps by Zephyr's sysbuild for example. Nothing conclusive. Anyway, it seems low risk to overwrite an empty string, which CMake can also treat as a "None" IIRC.